### PR TITLE
Format datetime as string queryString

### DIFF
--- a/sharedLibNet/MeterMonitorHelper.cs
+++ b/sharedLibNet/MeterMonitorHelper.cs
@@ -175,7 +175,9 @@ namespace sharedLibNet
                 if (offset > 0)
                     queries.Add(nameof(offset), offset.ToString());
                 queries.Add(nameof(withError), withError.ToString());
-                queries.Add(nameof(createdDate), createdDate.HasValue ? createdDate.Value.ToString() : DateTimeOffset.UtcNow.ToString());
+                string createdDateString = createdDate.HasValue ? createdDate.Value.ToString("yyyy-MM-dd") : DateTimeOffset.UtcNow.ToString("yyyy-MM-dd");
+                queries.Add(nameof(createdDate), createdDateString);
+                _logger.LogInformation($"MeterMonitor List request with createdDate: '{createdDateString}'");
 
                 HttpRequestMessage request = new HttpRequestMessage()
                 {


### PR DESCRIPTION
> [Fatal] => RequestId: => Function.GetLatestVersionFromDatabase.User  => Could not perform MeterMonitor List: Bad Request / {"errors":{"createdDate":["The value '25.07.2021 00:00:00 +02:00' is not valid."]},"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One or more validation errors occurred.","status":400,"traceId":"|2de213f8-41111b8b906f4799.2de213f9_d6aaee79_"}; GET to https://hfapi-stage.azure-api.net/metermonitor/  

https://my.papertrailapp.com/groups/12971571/events?q=program%3AServiceFunctions-Stage&focus=1359158186666102793&selected=1359158186666102793